### PR TITLE
encrypt card credentials

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-router-dom": "^5.1.7"
+    "@types/react-router-dom": "^5.1.7",
+    "openpgp": "*"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
+import * as openpgp from "openpgp";
+
 import React, { Component } from "react";
 
 import logo from "./logo.svg";
@@ -18,7 +20,8 @@ class App extends Component {
     description: "gift money",
     email: "hello@test.com",
     phoneNumber: "+12025550180",
-    cvv: "LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tDQpWZXJzaW9uOiBPcGVuUEdQLmpzIHY0LjEwLjQNCkNvbW1lbnQ6IGh0dHBzOi8vb3BlbnBncGpzLm9yZw0KDQp3Y0JNQTBYV1NGbEZScFZoQVFnQXF6N01LMmJiZnpWODBkeHZEeE11WnFIcU9peFVSY2ZHS2lOM0FrVjINCkl1N1lRMXRsVlVvSzArUVBCVFFxQ0JCdmNFV0RYYktjZmpqbmluMEJkVWR1NVNqdkJKRytmcmJMb3VXZQ0KUk5TWUdoczA5cGRwUjdnc2hYNjhqaEpnRWdVZzF4ZUt3V0FReFJwZE5OTzhxY3pUQnRhVkdBQ1Y3UW00DQpTSEtvQTJrWklmK2dtQy95K3VMSUswdVZDRUs0TkNlck9LRUc1MlJEUlI1MXU0K0xnUHNpZVN5bkoxSFINCklYMktJbWpTZWZsZHNvUHp2TW5KUFY3U2tjRzVHa3I2cWE4TnpsM1dTY2srdS9MZmdRQVRYOFdRM1FzOA0KWDRod0t2U293TnkxaEdEWnEvY0g3RVhSMlpuQnM4ZDdlM25oWGgxMHhXT3pvNEpIQko3Z2JrQk9CTU9aDQpqTkpoQVpXWU9ZNjlBT2EwVHhYZ3NqYUhxcGlud3BtQnJOMlorRExpeWt1U1UyYTNQVm93clV6aXJTOFINCm9qYndnd1d4Szg1TzZ1Y0Y2Tlo5WFdQWXBNUVFEY3dnVkliQ3Q1L3YvTk5BTzhnZXhheWlVS2FBS28wUw0KbHdyQitoSWYwdDNyNkE9PQ0KPVpMZjQNCi0tLS0tRU5EIFBHUCBNRVNTQUdFLS0tLS0NCg==",
+    cardNumber: "5102420000000006",
+    cvv: "123",
     expirationMonth: 1,
     expirationYear: 2025,
     cardholderName: "satoshi nakamoto",
@@ -44,9 +47,57 @@ class App extends Component {
     return body;
   };
 
+  // Gets public key and keyId from server
+  getPCIPublicKey = async () => {
+    const response = await fetch(SERVER_URL + "/encryption");
+
+    const responseBody = await response.json();
+
+    return {
+      keyId: responseBody.data.keyId,
+      publicKey: responseBody.data.publicKey,
+    };
+  };
+
+  // TODO: move all API calls to a Client module/component
+  encryptCredentials = async (cardCredentials: {
+    number: string;
+    cvv: string;
+  }) => {
+    const pciEncryptionKey = await this.getPCIPublicKey();
+
+    console.log("Obtained key. Now encrypting credentials");
+    const decodedPublicKey = atob(pciEncryptionKey.publicKey);
+    const publicKey = await openpgp.readKey({ armoredKey: decodedPublicKey });
+
+    return openpgp
+      .encrypt({
+        message: await openpgp.createMessage({
+          text: JSON.stringify(cardCredentials),
+        }),
+        encryptionKeys: publicKey,
+      })
+      .then((ciphertext) => {
+        return {
+          encryptedCredentials: btoa(ciphertext),
+          keyId: pciEncryptionKey.keyId,
+        };
+      });
+  };
+
   handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    console.log("submitting form!");
     event.preventDefault();
+
+    // Step 1: obtain the public key id and encrypt card credentials
+
+    var cardCredentials = {
+      number: this.state.cardNumber,
+      cvv: this.state.cvv,
+    };
+
+    var encryptedData = await this.encryptCredentials(cardCredentials);
+
+    // Step 2: Submit the payment
     const response = await fetch(SERVER_URL + "/payment", {
       method: "POST",
       headers: {
@@ -58,7 +109,8 @@ class App extends Component {
         email: this.state.email,
         phoneNumber: this.state.phoneNumber,
         verificationMethod: "cvv",
-        cvv: this.state.cvv,
+        cvv: encryptedData.encryptedCredentials,
+        keyId: encryptedData.keyId,
         sourceType: "card",
         expirationMonth: this.state.expirationMonth,
         expirationYear: this.state.expirationYear,
@@ -139,6 +191,17 @@ class App extends Component {
                 className="form-control"
                 value={this.state.phoneNumber}
                 onChange={(e) => this.setState({ phoneNumber: e.target.value })}
+              />
+            </label>
+          </div>
+          <div className="form-group">
+            <label>
+              Card Number
+              <input
+                type="text"
+                className="form-control"
+                value={this.state.cardNumber}
+                onChange={(e) => this.setState({ cvv: e.target.value })}
               />
             </label>
           </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,7 +201,7 @@ class App extends Component {
                 type="text"
                 className="form-control"
                 value={this.state.cardNumber}
-                onChange={(e) => this.setState({ cvv: e.target.value })}
+                onChange={(e) => this.setState({ cardNumber: e.target.value })}
               />
             </label>
           </div>

--- a/server/src/main/kotlin/com/tiden/flagship/circle/CircleClient.kt
+++ b/server/src/main/kotlin/com/tiden/flagship/circle/CircleClient.kt
@@ -118,7 +118,18 @@ data class CircleCreateCardResponse(
     val data: CreateCardResponseData,
 )
 
-fun createClient(): HttpClient {
+@Serializable
+data class PublicKeyResponseData(
+    val keyId: String,
+    val publicKey: String
+)
+
+@Serializable
+data class PublicKeyResponse(
+    val data: PublicKeyResponseData
+)
+
+fun createClient() : HttpClient{
     return HttpClient(CIO) {
         install(JsonFeature) {
             serializer = KotlinxSerializer()
@@ -161,6 +172,25 @@ suspend fun getStablecoins(): String {
     }
     println("got response: " + response.readText());
     client.close()
+    return response.readText()
+}
+
+// queries the Circle /public endpoint to get PGP key for encrypting card credentials
+suspend fun getPublicKey(): String {
+    val client = createClient();
+    val dotenv = dotenv {
+        directory = "../"
+        ignoreIfMalformed = true
+        ignoreIfMissing = true
+    }
+    val apiKey: String = dotenv["CIRCLE_API_KEY"]
+    val response: HttpResponse = client.get("https://api-sandbox.circle.com/v1/encryption/public") {
+
+        headers {
+            append(HttpHeaders.Accept, "application/json")
+            append(HttpHeaders.Authorization, "Bearer " + apiKey)
+        }
+    }
     return response.readText()
 }
 

--- a/server/src/main/kotlin/com/tiden/flagship/payment/models/PaymentRequest.kt
+++ b/server/src/main/kotlin/com/tiden/flagship/payment/models/PaymentRequest.kt
@@ -24,7 +24,9 @@ data class PaymentRequest(
     val district: String,
     val postalCode: String,
     // must be valid ISO 31660-2 country code
-    val country: String
+    val country: String,
+    // id of the pub key used for encrypting card credentials
+    val keyId: String? = null
     )
 
 // TODO: all data access objects should have method to transform data from

--- a/server/src/main/kotlin/com/tiden/flagship/payment/routes/PaymentRoutes.kt
+++ b/server/src/main/kotlin/com/tiden/flagship/payment/routes/PaymentRoutes.kt
@@ -55,11 +55,8 @@ fun Route.paymentRouting() {
         }
         post {
             val paymentRequest = call.receive<PaymentRequest>()
-            // Client makes a call to circle's /public endpoint to get a public key and encrypt card credentials (card num and CVV)
-            // The public key also comes with a keyId
-            // The encrypted CVV should be received here in the `encryptedData` field as a string
-            // TODO: client would pass in this keyId as a param after fetching public key. Once that's done, this code should extract from request params
-            val keyId = "key1"
+            // Unique identifier of pub key used in encryption. Not currently persisted
+            val keyId = paymentRequest.keyId.toString();
             // TODO: extract actual IP address
             val ipAddress = "172.33.222.1"
             // TODO: set up a sessionId (in client?)
@@ -130,6 +127,13 @@ fun Route.paymentRouting() {
         // calls the com.tiden.flagship.circle API for available stablecoins
         get {
             val response = com.tiden.flagship.circle.getStablecoins()
+            call.respondText(response)
+        }
+    }
+
+    route("/encryption") {
+        get {
+            val response = com.tiden.flagship.circle.getPublicKey();
             call.respondText(response)
         }
     }


### PR DESCRIPTION
Workflow for encrypting card credentials before sending to server
1. Client fetches public key from server (which gets it from circle)
2. Client uses OpenPGP to encrypt credentials before posting payment request
3. Enabled passing in `keyId` from client. Was previously hard-coded

Circle docs: https://developers.circle.com/docs/accept-card-payments-online
To be merged after https://github.com/jw122/tiden/pull/11 (rebase)