### PR TITLE
update merchant balance when payment successful

### DIFF
--- a/server/src/main/kotlin/com/tiden/flagship/payment/models/PaymentRequest.kt
+++ b/server/src/main/kotlin/com/tiden/flagship/payment/models/PaymentRequest.kt
@@ -26,7 +26,8 @@ data class PaymentRequest(
     // must be valid ISO 31660-2 country code
     val country: String,
     // id of the pub key used for encrypting card credentials
-    val keyId: String? = null
+    val keyId: String? = null,
+    val merchantId: String
     )
 
 // TODO: all data access objects should have method to transform data from

--- a/server/src/main/kotlin/com/tiden/flagship/payment/routes/PaymentRoutes.kt
+++ b/server/src/main/kotlin/com/tiden/flagship/payment/routes/PaymentRoutes.kt
@@ -107,13 +107,13 @@ fun Route.paymentRouting() {
             val circlePaymentResponse: CirclePaymentResponse? = makePayment(circlePaymentRequest)
 
             if (circlePaymentResponse != null) {
-                PaymentService.storeSuccessfulPayment(cardRequest, circlePaymentRequest, circlePaymentResponse.data)
+                PaymentService.storeSuccessfulPayment(cardRequest, paymentRequest, circlePaymentResponse.data)
                 call.respondText(
                     "Payment stored correctly: " + circlePaymentResponse.data.id,
                     status = HttpStatusCode.Created
                 )
             } else {
-                PaymentService.storeFailedPayment(cardRequest, circlePaymentRequest)
+                PaymentService.storeFailedPayment(cardRequest, paymentRequest)
                 call.respondText(
                     "unable to process payment: " + circlePaymentRequest.metadata,
                     status = HttpStatusCode.InternalServerError

--- a/store/migrations/0001.sql
+++ b/store/migrations/0001.sql
@@ -80,6 +80,8 @@ CREATE TABLE public.merchant_balance
     CONSTRAINT FK_merhant_balance_merchant FOREIGN KEY (merchant_id) REFERENCES merchant ("id")
 );
 
+INSERT INTO public.merchant_balance(id, amount, merchant_id) VALUES (1, 0, 1);
+
 CREATE INDEX index_fk_merchant_balance_merchant_id ON public.merchant_balance
     (
      merchant_id


### PR DESCRIPTION
To be merged after #12 
When a payment is successfully made, the merchant_balance table should be updated. This will allow for querying balances.
- Updated payment request to include merchant_id
- Update `merchant_balance` after payment is successful
- Seeding the merchant_balance table with merchant 1

